### PR TITLE
add interviewbit to mock interviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 * [Refdash](https://refdash.com/)
 * [Gainlo](http://www.gainlo.co/)
 * [Candidacy.io](https://www.candidacy.io/)
+* [InterviewBit](https://www.interviewbit.com/mock_interview/)
 
 ### Q&A
 * [How to prepare for my Google/Facebook interview if I have 6 months left?](http://www.quora.com/Career-Advice/What-are-the-ways-to-utilize-6-months-to-build-skill-set-to-get-into-Facebook-or-Google)


### PR DESCRIPTION
Interviewbit offers free one-on-one mock interviews. I have done it once and it was a really helpful experience. I hope others who are not aware of it can benefit from it.
It is already in the sites section but not mentioned in mock interviews section. Interview bit doesn't have mock interviews information on their home page. So, I think it can be added to mock interview section.